### PR TITLE
Replaced api.getmodule with redux props

### DIFF
--- a/Container.js
+++ b/Container.js
@@ -209,8 +209,6 @@ class Container extends React.Component {
     if(this.props.currentSettings.textSelect === 'drag'){
       dragToSelect = true;
     }
-    let proposedChangesStore = api.getDataFromCheckStore('ProposedChanges');
-    let commentBoxStore = api.getDataFromCheckStore('CommentBox');
     let direction = api.getDataFromCommon('params').direction == 'ltr' ? 'ltr' : 'rtl';
     let gatewayVerse = '';
     let targetVerse = '';
@@ -243,8 +241,6 @@ class Container extends React.Component {
         dragToSelect={dragToSelect}
         direction={direction}
         tabKey={this.state.tabKey}
-        commentBoxStore={commentBoxStore}
-        proposedChangesStore={proposedChangesStore}
         updateSelectedWords={this.updateSelectedWords.bind(this)}
         updateCheckStatus={this.updateCheckStatus.bind(this)}
         handleSelectTab={this.handleSelectTab.bind(this)}

--- a/Container.js
+++ b/Container.js
@@ -1,8 +1,7 @@
 //Api Consts
 const api = window.ModuleApi;
-const React = require('react');
-//Modules that are defined within translationNotes_Check_plugin
-const View = require('./View.js');
+import React from 'react'
+import View from './View.js'
 //String constants
 const NAMESPACE = "TranslationNotesChecker";
 

--- a/View.js
+++ b/View.js
@@ -2,38 +2,22 @@
  * @description:
  *  This class defines the entire view for translationNotes tool
  */
-//Api Consts
-const api = window.ModuleApi;
-const React = api.React;
-const RB = api.ReactBootstrap;
-//Bootstrap consts
-const {Row, Col, Tabs, Tab, Glyphicon} = RB;
-//Modules not defined within translationNotes
-let ScripturePane = null;
-let ProposedChanges = null;
-let CommentBox = null;
-let TranslationHelps = null;
-//Components
-const DragTargetVerseDisplay = require('./subcomponents/BareTargetVerseDisplay');
-const ClickTargetVerseDisplay = require('./subcomponents/TargetVerseDisplay');
-const GatewayVerseDisplay = require('./subcomponents/GatewayVerseDisplay.js');
-const CheckStatusButtons = require('./subcomponents/CheckStatusButtons');
-const ConfirmDisplay = require('./subcomponents/ConfirmDisplay');
-const HelpInfo = require('./subcomponents/HelpInfo');
-const style = require('./css/style');
-const CheckInfoCard = require('./subcomponents/CheckInfoCard.js');
+import React from 'react'
+import {Row, Col, Tabs, Tab, Glyphicon} from 'react-bootstrap'
+import DragTargetVerseDisplay from './subcomponents/BareTargetVerseDisplay'
+import ClickTargetVerseDisplay from './subcomponents/TargetVerseDisplay'
+import GatewayVerseDisplay from './subcomponents/GatewayVerseDisplay.js'
+import CheckStatusButtons from './subcomponents/CheckStatusButtons'
+import ConfirmDisplay from './subcomponents/ConfirmDisplay'
+import HelpInfo from './subcomponents/HelpInfo'
+import CheckInfoCard from './subcomponents/CheckInfoCard.js'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
-
+import style from './css/style'
 
 class View extends React.Component {
-  constructor(){
-    super();
-    ScripturePane = api.getModule('ScripturePane');
-    ProposedChanges = api.getModule('ProposedChanges');
-    CommentBox = api.getModule('CommentBox');
-    TranslationHelps = api.getModule('TranslationHelps');
-  }
   render(){
+    //Modules not defined within translationNotes
+    const { ScripturePane, ProposedChanges, CommentBox, TranslationHelps } = this.props.modules;
     let TargetVerseDisplay = null;
     if(this.props.dragToSelect){
       TargetVerseDisplay = <DragTargetVerseDisplay

--- a/View.js
+++ b/View.js
@@ -83,7 +83,7 @@ class View extends React.Component {
                         <div style={{height: "calc(100vh - 531px)", backgroundColor: "#333333", boxSizing: "border-box"}}>
                           <ProposedChanges currentCheck={this.props.currentCheck}
                                            updateCurrentCheck={this.props.updateCurrentCheck.bind(this)}
-                                           proposedChangesStore={this.props.proposedChangesStore} />
+                          />
                         </div>
                   </Tab>
                   <Tab eventKey={3} title={commentGlyph}
@@ -91,7 +91,7 @@ class View extends React.Component {
                         <div style={{height: "calc(100vh - 531px)", backgroundColor: "#333333", boxSizing: "border-box"}}>
                           <CommentBox currentCheck={this.props.currentCheck}
                                       updateCurrentCheck={this.props.updateCurrentCheck.bind(this)}
-                                      commentBoxStore={this.props.commentBoxStore} />
+                          />
                         </div>
                   </Tab>
                   <Tab eventKey={4} title={questionGlyph}

--- a/subcomponents/BareTargetVerseDisplay.js
+++ b/subcomponents/BareTargetVerseDisplay.js
@@ -1,6 +1,6 @@
-const React = require('react');
-const style = require('../css/style');
-const SelectionHelpers = require('../utils/selectionHelpers')
+import React from 'react'
+import style from '../css/style'
+import SelectionHelpers from '../utils/selectionHelpers'
 
 class TargetVerseDisplay extends React.Component {
   constructor() {

--- a/subcomponents/CheckInfoCard.js
+++ b/subcomponents/CheckInfoCard.js
@@ -1,17 +1,15 @@
 //CheckInfoCard.js//
 /**
- * @author Ian Hoegen
  * @description This component is a display component for the Check Info Cards.
  */
-const React = api.React;
-const RB = api.ReactBootstrap;
-const {Row, Glyphicon, Col} = RB;
-const styles = require('../css/style.js');
+import React from 'react'
+import {Row, Glyphicon, Col} from 'react-bootstrap'
+import styles from '../css/style.js'
 import {Card, CardActions, CardHeader, CardMedia, CardTitle, CardText} from 'material-ui/Card';
 
 class CheckInfoCard extends React.Component {
     render() {
-      var phraseInfo = this.props.file;
+      let phraseInfo = this.props.file;
       if(phraseInfo){
         phraseInfo = phraseInfo.replace(/\(See:.*/g,"");
       }

--- a/subcomponents/CheckInfoCard.js
+++ b/subcomponents/CheckInfoCard.js
@@ -1,5 +1,4 @@
-//CheckInfoCard.js//
-/**
+/** @file CheckInfoCard.js
  * @description This component is a display component for the Check Info Cards.
  */
 import React from 'react'

--- a/subcomponents/CheckStatusButtons.js
+++ b/subcomponents/CheckStatusButtons.js
@@ -1,10 +1,8 @@
-
-const api = window.ModuleApi;
-const React = api.React;
-const RB = api.ReactBootstrap;
-const {Glyphicon, Button, ButtonGroup, utils} = RB;
+import React from 'react'
+import { Glyphicon, Button, ButtonGroup, utils } from 'react-bootstrap'
+import style = from '../css/style'
+//bootstrapUtils declaration
 const bootstrapUtils = utils.bootstrapUtils;
-const style = require('../css/style');
 bootstrapUtils.addStyle(Button, 'correct');
 bootstrapUtils.addStyle(Button, 'flag');
 bootstrapUtils.addStyle(Button, 'darkGrey');

--- a/subcomponents/CheckStatusButtons.js
+++ b/subcomponents/CheckStatusButtons.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Glyphicon, Button, ButtonGroup, utils } from 'react-bootstrap'
-import style = from '../css/style'
+import style from '../css/style'
 //bootstrapUtils declaration
 const bootstrapUtils = utils.bootstrapUtils;
 bootstrapUtils.addStyle(Button, 'correct');

--- a/subcomponents/ConfirmDisplay.js
+++ b/subcomponents/ConfirmDisplay.js
@@ -1,6 +1,4 @@
-
-const api = window.ModuleApi;
-const React = api.React;
+import React from 'react'
 
 class ConfirmDisplay extends React.Component{
   render(){

--- a/subcomponents/GatewayVerseDisplay.js
+++ b/subcomponents/GatewayVerseDisplay.js
@@ -1,13 +1,9 @@
 ///GatewayVerseDisplay.js//
-
-const api = window.ModuleApi;
-const React = api.React;
-const ReactBootstrap = api.ReactBootstrap;
-
-let natural = require('natural');
-let XRegExp = require('xregexp');
-let nonUnicodeLetter = XRegExp('\\PL');
-
+import React from 'react'
+import natural from 'natural'
+import XRegExp from 'xregexp'
+//nonUnicodeLetter declaration
+const nonUnicodeLetter = XRegExp('\\PL');
 //Wordlength tokenizer
 const tokenizer = new natural.RegexpTokenizer({pattern: nonUnicodeLetter});
 

--- a/subcomponents/HelpInfo.js
+++ b/subcomponents/HelpInfo.js
@@ -1,4 +1,4 @@
-const React = api.React;
+import React from 'react'
 
 class HelpInfo extends React.Component{
   render(){

--- a/subcomponents/Loader.js
+++ b/subcomponents/Loader.js
@@ -1,8 +1,5 @@
-
-const api = window.ModuleApi;
-var React = api.React;
-var RB = api.ReactBootstrap;
-var {ProgressBar} = RB;
+import React from 'react'
+import { ProgressBar } from 'react-bootstrap'
 
 class Loader extends React.Component{
   render(){

--- a/subcomponents/TargetVerseDisplay.js
+++ b/subcomponents/TargetVerseDisplay.js
@@ -1,11 +1,11 @@
 ///TargetVerseDisplay.js//
-const React = require('react');
-//const natural = require('natural');
-const XRegExp = require('xregexp');
+import React from 'react'
+//import natural from 'natural'
+import XRegExp from 'xregexp'
+import TargetWord from './TargetWord'
+import style from '../css/style'
+//nonUnicodeLetter declaration
 const nonUnicodeLetter = XRegExp('[^\\pL\\pM]+?');
-const TargetWord = require('./TargetWord');
-const style = require('../css/style');
-
 //Wordlength tokenizer
 //const tokenizer = new natural.RegexpTokenizer({pattern: nonUnicodeLetter});
 

--- a/subcomponents/TargetWord.js
+++ b/subcomponents/TargetWord.js
@@ -1,6 +1,8 @@
-const React = require('react');
+/**
+ * @description Contains a word from the target language
+ */
+import React from 'react'
 
-/* Contains a word from the target language, defines a lot of listeners for clicks */
 class TargetWord extends React.Component {
     render() {
       return (


### PR DESCRIPTION
#### This pull request addresses:

- This branch is to be tested using **feature/mc-888** branch on tC repo
- https://github.com/unfoldingWord-dev/translationCore/pull/897
- **THelps has bugs that are unrelated to this PR**
- Change the way we require modules in order to import them using ES6 convention #900
#### How to test this pull request:

- Open tools and make sure the submodules render on the first load
- switch between tools and projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationnotes_check_plugin/41)
<!-- Reviewable:end -->
