### PR TITLE
issue 1066, update data in scripture pane when loading project

### DIFF
--- a/FetchData/ScripturePane.js
+++ b/FetchData/ScripturePane.js
@@ -25,8 +25,7 @@ var missingChunks = 0;
  * @param {object} actions - The functions that a tool has access to in order to store data
  * after it is loaded
  * @param {function} progress - Function to send to fetch data container to show progress
- * @param {boolean} scripturePaneSettings - its true if the scripture pane was preloaded
- * from the file system otherwise its false.
+ * @param {object} scripturePaneSettings - the current settings.
  * @returns {Promise} - Function that gets called when all the data is finished loading
  */
 export default function fetchData(projectDetails, bibles, actions, progress, scripturePaneSettings) {
@@ -34,11 +33,24 @@ export default function fetchData(projectDetails, bibles, actions, progress, scr
     const params = projectDetails.params;
     const tcManifest = projectDetails.manifest;
     const { addNewBible, setModuleSettings } = actions;
-    // Only generate ScripturePane settings if they were not previously generated and/or loaded from the filesystem.
+    const { currentPaneSettings, staticPaneSettings } = getPaneSettings(tcManifest);
+
+    setModuleSettings(NAMESPACE, 'staticPaneSettings', staticPaneSettings);
     if (!scripturePaneSettings) {
-      const { currentPaneSettings, staticPaneSettings } = getPaneSettings(tcManifest);
       setModuleSettings(NAMESPACE, 'currentPaneSettings', currentPaneSettings);
-      setModuleSettings(NAMESPACE, 'staticPaneSettings', staticPaneSettings);
+    } else {
+      var oldCurrentPaneSettings = scripturePaneSettings.currentPaneSettings;
+      var newCurrentPaneSettings = [];
+
+      oldCurrentPaneSettings.forEach(function (setting) {
+        var match = staticPaneSettings.filter(function (item) {
+          return item.sourceName === setting.sourceName;
+        });
+        if (match) {
+          newCurrentPaneSettings.push(match[0]);
+        }
+      });
+      setModuleSettings(NAMESPACE, 'currentPaneSettings', newCurrentPaneSettings);
     }
     getTargetLanguage().then(() => {
       progress(33);

--- a/FetchData/main.js
+++ b/FetchData/main.js
@@ -8,7 +8,7 @@ export default function fetchAllData(props) {
   const bibles = props.resourcesReducer.bibles;
   const actions = props.actions;
   const totalProgress = actions.progress;
-  const scripturePaneSettings = props.modulesSettingsReducer.ScripturePane ? true : false;
+  const scripturePaneSettings = props.modulesSettingsReducer.ScripturePane;
   const groupsDataLoaded = props.groupsDataReducer.loadedFromFileSystem;
   const groupsIndexLoaded = props.groupsIndexReducer.loadedFromFileSystem;
 


### PR DESCRIPTION
#### This pull request addresses:

ensure project data is updated in scripture pane when loading new tool or project



#### How to test this pull request:

Verify correct target language is listed in scripture pane for current project, even after switching project or tool.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationnotes_check_plugin/48)
<!-- Reviewable:end -->
