### PR TITLE
Allow Projects To Load Without Being Eph or Tit in Dev Mode

### DIFF
--- a/FetchData/TranslationNotes.js
+++ b/FetchData/TranslationNotes.js
@@ -53,7 +53,6 @@ export default function fetchData(projectDetails, bibles, actions, progress, gro
     addNewBible('gatewayLanguage', newStructure);
     chapterData = DoorDataFetcher.getTNFromBook(book, newStructure, params.bookAbbr, () => { });
     let filters = readFilters(convertToFullBookName(params.bookAbbr));
-    console.log(filters);
     parseObject(chapterData, tASectionList, addGroupData, setGroupsIndex, filters);
     progress(100);
     resolve();
@@ -110,9 +109,11 @@ export default function fetchData(projectDetails, bibles, actions, progress, gro
       for (var check in object[type]['verses']) {
         const currentCheck = object[type]['verses'][check];
         let found = false;
-        let currentFilter = filters.primary[currentCheck.chapter +":" + currentCheck.verse];
-        if (!currentFilter || !currentFilter.includes(currentCheck.phrase)) {
-          continue;
+        if (filters) {
+          let currentFilter = filters.primary[currentCheck.chapter + ":" + currentCheck.verse];
+          if (!currentFilter || !currentFilter.includes(currentCheck.phrase)) {
+            continue;
+          }
         }
         if (!checkObj[type]) checkObj[type] = [];
         checkObj[type].push({


### PR DESCRIPTION
#### This pull request addresses:
This PR checks the conditional for filters to bypass them and not break during the loading process

#### How to test this pull request:
Try to load projects other than tit/eph in dev mode

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationnotes_check_plugin/51)
<!-- Reviewable:end -->
