### PR TITLE
Fix missing phrase info

### DIFF
--- a/FetchData/TranslationNotes.js
+++ b/FetchData/TranslationNotes.js
@@ -126,12 +126,12 @@ export default function fetchData(projectDetails, bibles, actions, progress, gro
           if (!checkObj[type]) checkObj[type] = [];
           checkObj[type].push({
             priority: 1,
-            information: currentCheck.phraseInfo,
             comments: false,
             reminders: false,
             selections: false,
             verseEdits: false,
             contextId: {
+              information: currentCheck.phraseInfo,
               reference: {
                 bookId: currentCheck.book,
                 chapter: currentCheck.chapter,


### PR DESCRIPTION
#### This pull request addresses:

Addresses #1452

#### How to test this pull request:

Open translationNotes, and look at the Check Info Card. It should not have a missing section.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationnotes_check_plugin/60)
<!-- Reviewable:end -->
