### PR TITLE
Fixed THelps Width On Window Resize

### DIFF
--- a/View.js
+++ b/View.js
@@ -50,7 +50,7 @@ class View extends React.Component {
                        style={style.handleIcon}
                        onClick={this.props.toggleHelps} />
           </div>
-          <div style={{ display: this.props.showHelps ? "flex" : "none", flex: '1px' }}>
+          <div style={{ display: this.props.showHelps ? "flex" : "none", flex: '1' }}>
             <TranslationHelps
               {...this.props}
               currentFile={currentFile}

--- a/View.js
+++ b/View.js
@@ -39,18 +39,18 @@ class View extends React.Component {
 
     return (
       <div style={{display: 'flex', flex: 'auto'}}>
-        <div style={{flex: '2 1 1000px', display: "flex", flexDirection: "column"}}>
+        <div style={{flex: '2 1 900px', display: "flex", flexDirection: "column"}}>
           {scripturePane}
           <CheckInfoCard phraseTitle={groupName} openHelps={this.props.toggleHelps} showHelps={this.props.showHelps} title={contextIdReducer.contextId.quote} file={contextIdReducer.contextId.information} />
           <VerseCheck {...this.props} />
         </div>
-        <div style={{flex: this.props.showHelps ? '1 0 375px' : '0 0 30px', display: 'flex', justifyContent: 'flex-end', marginLeft: '-15px'}}>
+        <div style={{flex: this.props.showHelps ? '1 1 375px' : '0 0 30px', display: 'flex', justifyContent: 'flex-end', marginLeft: '-15px'}}>
           <div style={style.handleIconDiv}>
             <Glyphicon glyph={this.props.showHelps ? "chevron-right" : "chevron-left"}
                        style={style.handleIcon}
                        onClick={this.props.toggleHelps} />
           </div>
-          <div style={{ display: this.props.showHelps ? "flex" : "none", flex: '1 0 360px' }}>
+          <div style={{ display: this.props.showHelps ? "flex" : "none", flex: '1px' }}>
             <TranslationHelps
               {...this.props}
               currentFile={currentFile}


### PR DESCRIPTION
#### This pull request addresses:
This PR makes some changes to the flex properties in the tHelps modal to accommodate the minimum width for tC and window resizes.


#### How to test this pull request:
checkout the branches on tN, tW, and tHelps ```bugfix/jay/t-helps-resize/2512```
```cd tC_apps/TranslaitonHelps && git checkout bugfix/jay/t-helps-resize/2512```
```cd ../translationNotes && git checkout bugfix/jay/t-helps-resize/2512```
```cd ../translationWords && git checkout bugfix/jay/t-helps-resize/2512```
Open a tool in tC and ensure all the tHelps content is visible on window resize

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationnotes_check_plugin/79)
<!-- Reviewable:end -->
